### PR TITLE
Improve config example in dbicdump

### DIFF
--- a/script/dbicdump
+++ b/script/dbicdump
@@ -1,5 +1,7 @@
 #!/usr/bin/perl
 
+=encoding UTF-8
+
 =head1 NAME
 
 dbicdump - Dump a schema using DBIx::Class::Schema::Loader
@@ -82,7 +84,7 @@ L<DBIx::Class::Schema::Loader>, L<DBIx::Class>.
 
 =head1 AUTHOR
 
-Dagfinn Ilmari Manns?ker C<< <ilmari@ilmari.org> >>
+Dagfinn Ilmari Mannsåker C<< <ilmari@ilmari.org> >>
 
 =head1 CONTRIBUTORS
 


### PR DESCRIPTION
it was not apparent to me that dump_directory belongs into the
loader_options section, so make it obvious in the example
