### PR TITLE
ensure schema files are generated as binary files on windows

### DIFF
--- a/lib/DBIx/Class/Schema/Loader/Base.pm
+++ b/lib/DBIx/Class/Schema/Loader/Base.pm
@@ -2187,7 +2187,7 @@ sub _write_classfile {
       $self->omit_timestamp ? undef : POSIX::strftime('%Y-%m-%d %H:%M:%S', localtime)
     );
 
-    open(my $fh, '>:encoding(UTF-8)', $filename)
+    open(my $fh, '>:raw:encoding(UTF-8)', $filename)
         or croak "Cannot open '$filename' for writing: $!";
 
     # Write the top half and its MD5 sum

--- a/t/lib/dbixcsl_dumper_tests.pm
+++ b/t/lib/dbixcsl_dumper_tests.pm
@@ -210,19 +210,21 @@ sub _test_dumps {
     }
 }
 
-sub _dump_file_like {
+sub _slurp {
     my $path = shift;
-    open(my $dumpfh, '<', $path) or die "Failed to open '$path': $!";
+    open(my $dumpfh, '<:raw', $path) or die "Failed to open '$path': $!";
     my $contents = do { local $/; <$dumpfh>; };
     close($dumpfh);
+    return ($path, $contents);
+}
+
+sub _dump_file_like {
+    my ($path, $contents) = _slurp shift;
     like($contents, $_, "$path matches $_") for @_;
 }
 
 sub _dump_file_not_like {
-    my $path = shift;
-    open(my $dumpfh, '<', $path) or die "Failed to open '$path': $!";
-    my $contents = do { local $/; <$dumpfh>; };
-    close($dumpfh);
+    my ($path, $contents) = _slurp shift;
     unlike($contents, $_, "$path does not match $_") for @_;
 }
 


### PR DESCRIPTION
Otherwise they'll be generated with \r newlines in them, which breaks checksumming and portability of schemas to other OSes.