### PR TITLE
Tweak "exclude" and "constraint" option docs

### DIFF
--- a/lib/DBIx/Class/Schema/Loader/Base.pm
+++ b/lib/DBIx/Class/Schema/Loader/Base.pm
@@ -561,10 +561,6 @@ database and/or schema.
 
 Only load matching tables.
 
-=head2 exclude
-
-Exclude matching tables.
-
 These can be specified either as a regex (preferably on the C<qr//>
 form), or as an arrayref of arrayrefs.  Regexes are matched against
 the (unqualified) table name, while arrayrefs are matched according to
@@ -581,6 +577,13 @@ For example:
 
 In this case only the tables C<foo> and C<bar> in C<some_schema> and
 C<baz> in C<other_schema> will be dumped.
+
+=head2 exclude
+
+Exclude matching tables.
+
+The tables to exclude are specified in the same way as for the
+L</constraint> option.
 
 =head2 moniker_map
 


### PR DESCRIPTION
A user reading the documentation online may click on a TOC link to the
"exclude" option, not seeing that the description also applies to the
"constraint" option immediately above. This commit seeks to remedy that
by moving the description to the "constraint" section and giving
"exclude" and explicit backward reference to it.