### PR TITLE
Use hashref (not hash) for connection info options

### DIFF
--- a/script/dbicdump
+++ b/script/dbicdump
@@ -158,7 +158,7 @@ if (@ARGV == 1) {
     make_schema_at(
         $c->{schema_class},
         $c->{loader_options} || {},
-        [ $dsn, $user, $pass, %{$options} ],
+        [ $dsn, $user, $pass, $options ],
     );
 }
 else {

--- a/t/61dbicdump_config_options.t
+++ b/t/61dbicdump_config_options.t
@@ -1,0 +1,65 @@
+use DBIx::Class::Schema::Loader::Optional::Dependencies
+    -skip_all_without => 'test_dbicdump_config';
+
+use strict;
+use warnings;
+
+use Test::More;
+use File::Path qw/make_path rmtree/;
+use DBIx::Class::Schema::Loader::Utils 'slurp_file';
+use Try::Tiny;
+use namespace::clean;
+use lib 't/lib';
+use make_dbictest_db ();
+use dbixcsl_test_dir '$tdir';
+
+plan tests => 2;
+
+my $config_dir  = "$tdir/dbicdump_config";
+make_path $config_dir;
+my $config_file = "$config_dir/my.conf";
+
+my $dump_path   = "$tdir/dbicdump_config_dump";
+
+open my $fh, '>', $config_file
+    or die "Could not write to $config_file: $!";
+
+print $fh <<"EOF";
+schema_class DBICTest::Schema
+
+lib t/lib
+
+<connect_info>
+    dsn $make_dbictest_db::dsn
+    <options>
+        LongReadLen         100000000
+        LongTrunkOk         1
+    </options>
+</connect_info>
+
+<loader_options>
+    dump_directory    $dump_path
+    components        InflateColumn::DateTime
+    schema_base_class TestSchemaBaseClass
+    quiet             1
+</loader_options>
+EOF
+
+close $fh;
+
+system $^X, 'script/dbicdump', $config_file;
+
+is $? >> 8, 0,
+    'dbicdump executed successfully';
+
+my $foo = try { slurp_file "$dump_path/DBICTest/Schema/Result/Foo.pm" } || '';
+
+like $foo, qr/InflateColumn::DateTime/,
+    'loader options read correctly from config_file';
+
+done_testing;
+
+END {
+    rmtree($config_dir, 1, 1);
+    rmtree($dump_path,  1, 1);
+}


### PR DESCRIPTION
Trying to specify DBI connection options in dbicdump config.

I may have misunderstood usage, but it looks like [connect](http://search.cpan.org/~ribasushi/DBIx-Class-0.082840/lib/DBIx/Class/Storage/DBI.pm#connect_info) allows DBI connection options to be given as a hashref, eg

```
$options = { LongTrunkOk => 1 };
My::Schema->connect($dsn, $user, $pass, $options);
```

However, I think `dbicdump` is currently passing them in as a [(de-referenced) hash:](https://github.com/dbsrgits/dbix-class-schema-loader/compare/master...sillitoe:dbicdump-config-connect-with-options?expand=1#diff-7479a2c1349f0300899e26041504604eL161)

```
     make_schema_at(
         $c->{schema_class},
         $c->{loader_options} || {},
         [ $dsn, $user, $pass, %{$options} ],
     );
```

This PR changes `%{$options}` to `$options`, which allows DBI connection options to be specified in the config as:

```
<connect_info>
    dsn     dbi:Oracle:host=xxx;sid=xxx
    user    xxx
    pass    xxx
    <options>
        LongReadLen         100000000
        LongTrunkOk         1
    </options>
</connect_info>
```

Full details appended.

---

I was having difficulty passing connect options through to `dbicdump` (via `Config::Any`), e.g trying to dump the schema from an Oracle database requires the following connection options:

```
      LongReadLen         100000000
      LongTrunkOk         1
```

Based on the [DBIx::Class::Storage::DBI docs](http://search.cpan.org/~ribasushi/DBIx-Class-0.082840/lib/DBIx/Class/Storage/DBI.pm#connect_info), I thought the best way to do this in `dbic.conf` was:

```
<connect_info>
    dsn     dbi:Oracle:host=xxx;sid=xxx
    user    xxx
    pass    xxx
    LongReadLen         100000000
    LongTrunkOk         1
</connect_info>
```

However this came up with an error that seemed to suggest these options weren't being used.

```
DBIx::Class::Schema::Loader::DBI::Oracle::_view_definition(): DBI Exception: DBD::Oracle::db selectrow_array failed: ORA-24345: A Truncation or null fetch error occurred (DBD ERROR: ORA-01406 error on field 1 of 1, ora_type 8, LongReadLen too small and/or LongTruncOk not set)
```

From the code, it looks like dbicdump allows a config key `options` within `connect_info` so I tried:

```
<connect_info>
    dsn     dbi:Oracle:host=xxx;sid=xxx
    user    xxx
    pass    xxx
    <options>
        LongReadLen         100000000
        LongTrunkOk         1
    </options>
</connect_info>
```

However, this gave the error:

```
Can't use string ("LongTrunkOk") as a HASH ref while "strict refs" in use at /cath/homes2/ucbcisi/.plenv/versions/5.12.5/lib/perl5/site_perl/5.12.5/DBIx/Class/Storage/DBI.pm line 733.
```

It looks like `DBIC->connect` can accept these options as a hashref, but dbicdump is currently passing them in as a (de-referenced) hash. Applying the change in this PR seemed to make everything work for me.

Existing tests all pass. I've added a test to make sure the new config with options parses okay (fails prior to this PR). It currently throws out a warning though (I think because the test database isn't DBD::Oracle).
