### PR TITLE
do not require MooseX::MarkAsMethods with only_autoclean=1

### DIFF
--- a/lib/DBIx/Class/Schema/Loader/Base.pm
+++ b/lib/DBIx/Class/Schema/Loader/Base.pm
@@ -990,12 +990,13 @@ are methods, which will cause namespace::autoclean to spare them from removal.
 
 This prevents the "Hey, where'd my overloads go?!" effect.
 
-If you don't care about operator overloads, enabling this option falls back to
-just using L<namespace::autoclean> itself.
+If you don't care about operator overloads (or if you know your Moose is at at
+least version 2.1400, where MooseX::MarkAsMethods is no longer necessary),
+enabling this option falls back to just using L<namespace::autoclean> itself.
 
 If none of the above made any sense, or you don't have some pressing need to
 only use L<namespace::autoclean>, leaving this set to the default is
-recommended.
+just fine.
 
 =head2 col_collision_map
 
@@ -1181,9 +1182,17 @@ sub new {
     $self->_validate_result_roles_map;
 
     if ($self->use_moose) {
-        if (not DBIx::Class::Schema::Loader::Optional::Dependencies->req_ok_for('use_moose')) {
-            die sprintf "You must install the following CPAN modules to enable the use_moose option: %s.\n",
-                DBIx::Class::Schema::Loader::Optional::Dependencies->req_missing_for('use_moose');
+        if ($self->only_autoclean) {
+            if (not DBIx::Class::Schema::Loader::Optional::Dependencies->req_ok_for('use_moose_only_autoclean')) {
+                die sprintf "You must install the following CPAN modules to enable the use_moose and only_autoclean options: %s.\n",
+                    DBIx::Class::Schema::Loader::Optional::Dependencies->req_missing_for('use_moose_only_autoclean');
+            }
+        }
+        else {
+            if (not DBIx::Class::Schema::Loader::Optional::Dependencies->req_ok_for('use_moose')) {
+                die sprintf "You must install the following CPAN modules to enable the use_moose option: %s.\n",
+                    DBIx::Class::Schema::Loader::Optional::Dependencies->req_missing_for('use_moose');
+            }
         }
     }
 

--- a/lib/DBIx/Class/Schema/Loader/Optional/Dependencies.pm
+++ b/lib/DBIx/Class/Schema/Loader/Optional/Dependencies.pm
@@ -32,7 +32,18 @@ my $dbic_reqs = {
     },
     pod => {
       title => 'use_moose',
-      desc  => 'Modules required for the use_moose option',
+      desc  => 'Modules required for the use_moose option (without only_autoclean)',
+    },
+  },
+  use_moose_only_autoclean => {
+    req => {
+      'Moose' => '2.1400',
+      'MooseX::NonMoose' => '0.25',
+      'namespace::autoclean' => '0.09',
+    },
+    pod => {
+      title => 'use_moose_only_autoclean',
+      desc  => 'Modules required for the use_moose + only_autoclean options',
     },
   },
 
@@ -981,6 +992,7 @@ sub _gen_pod {
 
   File::Path::mkpath([$dir]);
 
+  # used in example pod
   my $moosever = $class->req_list_for('use_moose')->{'Moose'}
     or die "Hrmm? No Moose dep?";
 

--- a/t/lib/dbixcsl_common_tests.pm
+++ b/t/lib/dbixcsl_common_tests.pm
@@ -224,9 +224,14 @@ sub setup_schema {
     my $debug = ($self->{verbose} > 1) ? 1 : 0;
 
     if ($ENV{SCHEMA_LOADER_TESTS_USE_MOOSE}) {
+        # on travis, we require the intersection of both sets of prereqs
         if (not DBIx::Class::Schema::Loader::Optional::Dependencies->req_ok_for('use_moose')) {
             die sprintf ("Missing dependencies for SCHEMA_LOADER_TESTS_USE_MOOSE: %s\n",
                 DBIx::Class::Schema::Loader::Optional::Dependencies->req_missing_for('use_moose'));
+        }
+        if (not DBIx::Class::Schema::Loader::Optional::Dependencies->req_ok_for('use_moose_only_autoclean')) {
+            die sprintf ("Missing dependencies for SCHEMA_LOADER_TESTS_USE_MOOSE: %s\n",
+                DBIx::Class::Schema::Loader::Optional::Dependencies->req_missing_for('use_moose_only_autoclean'));
         }
 
         $self->{use_moose} = 1;


### PR DESCRIPTION
When use_moose=1 and only_autoclean=1, we do not require
MooseX::MarkAsMethods, but require a more recent version of Moose. Check
for whichever set of prereqs is appropriate.
    
Technically, we don't need MXMAM at all if Moose is at 2.1400, but the
generated code will still (for now) use the MXMAM constructs if
only_autoclean is not set.  This gives the user more flexibility if
their Moose installation isn't at a new enough version on all systems.