### PR TITLE
Handle current_timestamp() from MariaDB DESCRIBE

### DIFF
--- a/lib/DBIx/Class/Schema/Loader/DBI/mysql.pm
+++ b/lib/DBIx/Class/Schema/Loader/DBI/mysql.pm
@@ -302,7 +302,7 @@ sub _extra_column_info {
         $extra_info{extra}{list} = $dbi_info->{mysql_values};
     }
     if ((not blessed $dbi_info) # isa $sth
-        && lc($dbi_info->{COLUMN_DEF})      eq 'current_timestamp'
+        && lc($dbi_info->{COLUMN_DEF})      =~ m/^current_timestamp/
         && lc($dbi_info->{mysql_type_name}) eq 'timestamp') {
 
         my $current_timestamp = 'current_timestamp';


### PR DESCRIPTION
At some point, MariaDB started outputing 'current_timestamp()' in the
default field when DESCRIBE is called on the table. This is a change
from 'CURRENT_TIMESTAMP' in mysql and older versions of mariadb.  As
such, our equality match started to fail and resulting schema dumps
produced `current_timestamp()` instead of `\"current_timestamp"`

I wasn't sure where to add a test for this.. if you guide me as to where I'm happy to add one.