### PR TITLE
Fix timestamp defaults in MariaDB 10.2.3 and later

### DIFF
--- a/lib/DBIx/Class/Schema/Loader/DBI/mysql.pm
+++ b/lib/DBIx/Class/Schema/Loader/DBI/mysql.pm
@@ -301,9 +301,12 @@ sub _extra_column_info {
     if ($dbi_info->{mysql_values}) {
         $extra_info{extra}{list} = $dbi_info->{mysql_values};
     }
+
+    # TODO MariaDB docs say that the precision may be specified inside the
+    # brackets.
     if ((not blessed $dbi_info) # isa $sth
-        && lc($dbi_info->{COLUMN_DEF})      =~ m/^current_timestamp(?:\(\))?$/
-        && lc($dbi_info->{mysql_type_name}) eq 'timestamp') {
+        && $dbi_info->{COLUMN_DEF}      =~ m/^current_timestamp(?:\(\))?$/i
+        && $dbi_info->{mysql_type_name} =~ m/^(?:timestamp|datetime)$/i) {
 
         my $current_timestamp = 'current_timestamp';
         $extra_info{default_value} = \$current_timestamp;

--- a/lib/DBIx/Class/Schema/Loader/DBI/mysql.pm
+++ b/lib/DBIx/Class/Schema/Loader/DBI/mysql.pm
@@ -302,7 +302,7 @@ sub _extra_column_info {
         $extra_info{extra}{list} = $dbi_info->{mysql_values};
     }
     if ((not blessed $dbi_info) # isa $sth
-        && lc($dbi_info->{COLUMN_DEF})      eq 'current_timestamp'
+        && lc($dbi_info->{COLUMN_DEF})      =~ m/^current_timestamp/
         && lc($dbi_info->{mysql_type_name}) eq 'timestamp') {
 
         my $current_timestamp = 'current_timestamp';

--- a/lib/DBIx/Class/Schema/Loader/DBI/mysql.pm
+++ b/lib/DBIx/Class/Schema/Loader/DBI/mysql.pm
@@ -302,7 +302,7 @@ sub _extra_column_info {
         $extra_info{extra}{list} = $dbi_info->{mysql_values};
     }
     if ((not blessed $dbi_info) # isa $sth
-        && lc($dbi_info->{COLUMN_DEF})      =~ m/^current_timestamp/
+        && lc($dbi_info->{COLUMN_DEF})      =~ m/^current_timestamp(?:\(\))?$/
         && lc($dbi_info->{mysql_type_name}) eq 'timestamp') {
 
         my $current_timestamp = 'current_timestamp';

--- a/t/10_02mysql_common.t
+++ b/t/10_02mysql_common.t
@@ -116,6 +116,10 @@ dbixcsl_common_tests->new(
         'datetime'    => { data_type => 'datetime', datetime_undef_if_invalid => 1 },
         'timestamp default current_timestamp'
                       => { data_type => 'timestamp', default_value => \'current_timestamp', datetime_undef_if_invalid => 1 },
+        'timestamp not null default current_timestamp()'
+                      => { data_type => 'timestamp', default_value => \'current_timestamp', datetime_undef_if_invalid => 1 },
+        'datetime not null default current_timestamp()'
+                      => { data_type => 'datetime', default_value => \'current_timestamp', datetime_undef_if_invalid => 1 },
         'time'        => { data_type => 'time' },
         'year'        => { data_type => 'year' },
         'year(4)'     => { data_type => 'year' },


### PR DESCRIPTION
This patch handles a behaviour change preventing schemas using `DEFAULT current_timestamp()` from being correctly imported from MariaDB.

MariaDB made a change about five years ago which causes it to say `current_timestamp()` rather than `current_timestamp` when outputting schema. This was quite deliberate, see https://jira.mariadb.org/browse/MDEV-13377 and https://github.com/MariaDB/server/commit/a411d7f4f670c24b43b50f7d2a1129e10218f4a7

This builds on @mrenvoize's unmerged https://github.com/dbsrgits/dbix-class-schema-loader/pull/23 .