### PR TITLE
Use retrieve_on_insert for defaulting PK cols

### DIFF
--- a/lib/DBIx/Class/Schema/Loader/DBI/Pg.pm
+++ b/lib/DBIx/Class/Schema/Loader/DBI/Pg.pm
@@ -348,6 +348,7 @@ EOF
             # on insert even if it's not serial specifically
             if (!$info->{is_auto_increment}) {
               %pkeys = map { $_ => 1 } @{ $self->_table_pk_info($table) } unless %pkeys;
+
               if ($pkeys{$col}){
                 $info->{retrieve_on_insert} = 1
               }


### PR DESCRIPTION
closes #28

- feat: add retrieve_on_insert to all primary_keys generated from functions
- feat: ensure new roi feature is tested
